### PR TITLE
V1.3.1

### DIFF
--- a/Prism.CommonDialogPack-Sample-MahApps/App.xaml
+++ b/Prism.CommonDialogPack-Sample-MahApps/App.xaml
@@ -4,6 +4,11 @@
              xmlns:local="clr-namespace:Prism.CommonDialogPack_Sample_MahApps"
              xmlns:prism="http://prismlibrary.com/">
     <Application.Resources>
-        <ResourceDictionary Source="/MahAppsStyle.xaml"/>
-    </Application.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.MergedDictionaries>
+				<ResourceDictionary Source="/MahAppsStyle.xaml"/>
+				<ResourceDictionary Source="/DialogStyles.xaml"/>
+			</ResourceDictionary.MergedDictionaries>
+		</ResourceDictionary>
+	</Application.Resources>
 </prism:PrismApplication>

--- a/Prism.CommonDialogPack-Sample-MahApps/DialogStyles.xaml
+++ b/Prism.CommonDialogPack-Sample-MahApps/DialogStyles.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:Prism.CommonDialogPack_Sample_MahApps">
+    <Style TargetType="Window" x:Key="dialogStyle">
+        <Setter Property="ResizeMode"
+                Value="CanResizeWithGrip"/>
+        <Setter Property="SizeToContent"
+                Value="WidthAndHeight"/>
+    </Style>
+</ResourceDictionary>

--- a/Prism.CommonDialogPack-Sample-MahApps/ViewModels/MainWindowViewModel.cs
+++ b/Prism.CommonDialogPack-Sample-MahApps/ViewModels/MainWindowViewModel.cs
@@ -67,16 +67,19 @@ namespace Prism.CommonDialogPack_Sample_MahApps.ViewModels
         private void ShowNotificationDialog()
         {
             // Standard
-            //var param = new DialogParameters
-            //{
-            //    { DialogParameterNames.Message, "Notification" },
-            //    { DialogParameterNames.Title, "Notification" },
-            //    { DialogParameterNames.WindowStyle, (System.Windows.Style)App.Current.FindResource("dialogStyle") },
-            //};
-            //this.dialogService.ShowDialog(DialogNames.Notification, param, res => this.ResultMessage.Value = "Notification");
+            var param = new DialogParameters
+            {
+                { DialogParameterNames.Message, "Notification" },
+                { DialogParameterNames.Title, "Notification" },
+                // When specifying a WindowStyle StyleKey as a string.
+                { DialogParameterNames.WindowStyle, "dialogStyle" },
+                // When specifying WindowStyle directly.
+                //{ DialogParameterNames.WindowStyle, (System.Windows.Style)App.Current.FindResource("dialogStyle") },
+            };
+            this.dialogService.ShowDialog(DialogNames.Notification, param, res => this.ResultMessage.Value = "Notification");
 
             // Extensions
-            this.dialogService.ShowNotificationDialog("Notification", "Notification", res => this.ResultMessage.Value = "Notification");
+            //this.dialogService.ShowNotificationDialog("Notification", "Notification", res => this.ResultMessage.Value = "Notification");
         }
         /// <summary>
         /// Show ConfirmationDialog.

--- a/Prism.CommonDialogPack-Sample-MahApps/ViewModels/MainWindowViewModel.cs
+++ b/Prism.CommonDialogPack-Sample-MahApps/ViewModels/MainWindowViewModel.cs
@@ -443,6 +443,7 @@ namespace Prism.CommonDialogPack_Sample_MahApps.ViewModels
                 tokenSource.Dispose();
             });
         }
+        private RGB? selectedColor;
         /// <summary>
         /// Show ColorPickerDialog.
         /// </summary>
@@ -451,7 +452,15 @@ namespace Prism.CommonDialogPack_Sample_MahApps.ViewModels
             var param = new DialogParameters()
             {
                 { DialogParameterNames.Title, "ColorPicker" },
+                // Can specify default color in RGB, HSV, and ColorCode.
+                //{ DialogParameterNames.DefaultColor, new RGB(255, 255, 0) },
+                //{ DialogParameterNames.DefaultColor, new HSV(60, 1, 1) },
+                //{ DialogParameterNames.DefaultColor, "#FFFF00" },
             };
+            if (this.selectedColor.HasValue)
+            {
+                param.Add(DialogParameterNames.DefaultColor, this.selectedColor.Value);
+            }
             this.dialogService.ShowColorPickerDialog(param, res =>
             {
                 if (res.Result == ButtonResult.OK)
@@ -462,6 +471,7 @@ namespace Prism.CommonDialogPack_Sample_MahApps.ViewModels
                     stringBuilder.AppendLine($"HSV: {res.HSV}");
                     stringBuilder.AppendLine($"ColorCode: {res.ColorCode}");
                     this.ResultMessage.Value = stringBuilder.ToString();
+                    selectedColor = res.RGB;
                 }
                 else if (res.Result == ButtonResult.Cancel)
                 {

--- a/Prism.CommonDialogPack-Sample/ViewModels/MainWindowViewModel.cs
+++ b/Prism.CommonDialogPack-Sample/ViewModels/MainWindowViewModel.cs
@@ -67,16 +67,19 @@ namespace Prism.CommonDialogPack_Sample.ViewModels
         private void ShowNotificationDialog()
         {
             // Standard
-            //var param = new DialogParameters
-            //{
-            //    { DialogParameterNames.Message, "Notification" },
-            //    { DialogParameterNames.Title, "Notification" },
-            //    { DialogParameterNames.WindowStyle, (System.Windows.Style)App.Current.FindResource("dialogStyle") },
-            //};
-            //this.dialogService.ShowDialog(DialogNames.Notification, param, res => this.ResultMessage.Value = "Notification");
+            var param = new DialogParameters
+            {
+                { DialogParameterNames.Message, "Notification" },
+                { DialogParameterNames.Title, "Notification" },
+                // When specifying a WindowStyle StyleKey as a string.
+                { DialogParameterNames.WindowStyle, "dialogStyle" },
+                // When specifying WindowStyle directly.
+                //{ DialogParameterNames.WindowStyle, (System.Windows.Style)App.Current.FindResource("dialogStyle") },
+            };
+            this.dialogService.ShowDialog(DialogNames.Notification, param, res => this.ResultMessage.Value = "Notification");
 
             // Extensions
-            this.dialogService.ShowNotificationDialog("Notification", "Notification", res => this.ResultMessage.Value = "Notification");
+            //this.dialogService.ShowNotificationDialog("Notification", "Notification", res => this.ResultMessage.Value = "Notification");
         }
         /// <summary>
         /// Show ConfirmationDialog.

--- a/Prism.CommonDialogPack-Sample/ViewModels/MainWindowViewModel.cs
+++ b/Prism.CommonDialogPack-Sample/ViewModels/MainWindowViewModel.cs
@@ -443,6 +443,7 @@ namespace Prism.CommonDialogPack_Sample.ViewModels
                 tokenSource.Dispose();
             });
         }
+        private RGB? selectedColor;
         /// <summary>
         /// Show ColorPickerDialog.
         /// </summary>
@@ -451,7 +452,15 @@ namespace Prism.CommonDialogPack_Sample.ViewModels
             var param = new DialogParameters()
             {
                 { DialogParameterNames.Title, "ColorPicker" },
+                // Can specify default color in RGB, HSV, and ColorCode.
+                //{ DialogParameterNames.DefaultColor, new RGB(255, 255, 0) },
+                //{ DialogParameterNames.DefaultColor, new HSV(60, 1, 1) },
+                //{ DialogParameterNames.DefaultColor, "#FFFF00" },
             };
+            if (this.selectedColor.HasValue)
+            {
+                param.Add(DialogParameterNames.DefaultColor, this.selectedColor.Value);
+            }
             this.dialogService.ShowColorPickerDialog(param, res =>
             {
                 if (res.Result == ButtonResult.OK)
@@ -462,6 +471,7 @@ namespace Prism.CommonDialogPack_Sample.ViewModels
                     stringBuilder.AppendLine($"HSV: {res.HSV}");
                     stringBuilder.AppendLine($"ColorCode: {res.ColorCode}");
                     this.ResultMessage.Value = stringBuilder.ToString();
+                    selectedColor = res.RGB;
                 }
                 else if (res.Result == ButtonResult.Cancel)
                 {

--- a/Prism.CommonDialogPack/Controls/HSVPicker/HSVPicker.cs
+++ b/Prism.CommonDialogPack/Controls/HSVPicker/HSVPicker.cs
@@ -66,6 +66,16 @@ namespace Prism.CommonDialogPack.Controls
         public static readonly DependencyProperty SelectedHSVProperty =
             DependencyProperty.Register("SelectedHSV", typeof(HSV), typeof(HSVPicker), new PropertyMetadata(new HSV(0, 0, 1)));
 
+        [Description("DefaultHSV"), Category("共通")]
+        public HSV DefaultHSV
+        {
+            get { return (HSV)GetValue(DefaultHSVProperty); }
+            set { SetValue(DefaultHSVProperty, value); }
+        }
+        // Using a DependencyProperty as the backing store for DefaultHSV.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty DefaultHSVProperty =
+            DependencyProperty.Register("DefaultHSV", typeof(HSV), typeof(HSVPicker), new PropertyMetadata(new HSV(0, 0, 1)));
+
         HSPicker hsPicker;
         BrightnessSlider brightnessSlider;
 
@@ -82,6 +92,11 @@ namespace Prism.CommonDialogPack.Controls
         static HSVPicker()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(HSVPicker), new FrameworkPropertyMetadata(typeof(HSVPicker)));
+        }
+
+        public HSVPicker()
+        {
+            this.Loaded += HSVPicker_Loaded;
         }
 
         public override void OnApplyTemplate()
@@ -108,6 +123,15 @@ namespace Prism.CommonDialogPack.Controls
             {
                 this.brightnessSlider.BrightnessChangedEvent += OnBrightnessChanged;
             }
+        }
+
+        private void HSVPicker_Loaded(object sender, RoutedEventArgs e)
+        {
+            this.hsPicker.DefaultHue = this.DefaultHSV.H;
+            this.hsPicker.DefaultSaturation = this.DefaultHSV.S;
+            this.hsPicker.Hue = this.DefaultHSV.H;
+            this.hsPicker.Saturation = this.DefaultHSV.S;
+            this.brightnessSlider.DefaultBrightness = this.DefaultHSV.V;
         }
         /// <summary>
         /// It is called when "HSChanged" from HSPicker.

--- a/Prism.CommonDialogPack/DialogParameterNames.cs
+++ b/Prism.CommonDialogPack/DialogParameterNames.cs
@@ -40,5 +40,6 @@
         public static readonly string ProgressCompleteNotificationTitle = nameof(ProgressCompleteNotificationTitle);
         public static readonly string ProgressCompleteNotificationMessage = nameof(ProgressCompleteNotificationMessage);
         public static readonly string ProgressCompleteNotificationButtonText = nameof(ProgressCompleteNotificationButtonText);
+        public static readonly string DefaultColor = nameof(DefaultColor);
     }
 }

--- a/Prism.CommonDialogPack/DialogParameterNames.cs
+++ b/Prism.CommonDialogPack/DialogParameterNames.cs
@@ -17,6 +17,7 @@
         public static readonly string CancelButtonText = nameof(CancelButtonText);
         public static readonly string SelectButtonText = nameof(SelectButtonText);
         public static readonly string SaveButtonText = nameof(SaveButtonText);
+        public static readonly string AddCustomColorButtonText = nameof(AddCustomColorButtonText);
         public static readonly string FolderNamePrefixText = nameof(FolderNamePrefixText);
         public static readonly string FileNamePrefixText = nameof(FileNamePrefixText);
         public static readonly string FileTypePrefixText = nameof(FileTypePrefixText);

--- a/Prism.CommonDialogPack/Models/HSV.cs
+++ b/Prism.CommonDialogPack/Models/HSV.cs
@@ -1,8 +1,9 @@
 ﻿using Prism.CommonDialogPack.Converters;
+using System;
 
 namespace Prism.CommonDialogPack.Models
 {
-    public struct HSV
+    public struct HSV : IEquatable<HSV>
     {
         /// <summary>
         /// Hue(色相) 0～360
@@ -99,6 +100,33 @@ namespace Prism.CommonDialogPack.Models
         public static HSV FromMediaColor(System.Windows.Media.Color color)
         {
             return ColorConverter.RGBToHSV(color.R, color.B, color.B);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is HSV hSV && Equals(hSV);
+        }
+
+        public bool Equals(HSV other)
+        {
+            return H == other.H &&
+                   S == other.S &&
+                   V == other.V;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(H, S, V);
+        }
+
+        public static bool operator ==(HSV left, HSV right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(HSV left, HSV right)
+        {
+            return !(left == right);
         }
     }
 }

--- a/Prism.CommonDialogPack/Models/RGB.cs
+++ b/Prism.CommonDialogPack/Models/RGB.cs
@@ -1,9 +1,10 @@
 ﻿using Prism.CommonDialogPack.Converters;
+using System;
 using System.Resources;
 
 namespace Prism.CommonDialogPack.Models
 {
-    public struct RGB
+    public struct RGB : IEquatable<RGB>
     {
         /// <summary>
         /// Red
@@ -123,6 +124,33 @@ namespace Prism.CommonDialogPack.Models
         public static RGB FromString(string colorCode)
         {
             return ColorConverter.StringToRGB(colorCode);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RGB rGB && Equals(rGB);
+        }
+
+        public bool Equals(RGB other)
+        {
+            return R == other.R &&
+                   G == other.G &&
+                   B == other.B;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(R, G, B);
+        }
+
+        public static bool operator ==(RGB left, RGB right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RGB left, RGB right)
+        {
+            return !(left == right);
         }
     }
 }

--- a/Prism.CommonDialogPack/Prism.CommonDialogPack.csproj
+++ b/Prism.CommonDialogPack/Prism.CommonDialogPack.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Authors>Kuro</Authors>
     <PackageProjectUrl>https://github.com/Kuro4/Prism.CommonDialogPack</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Kuro4/Prism.CommonDialogPack</RepositoryUrl>

--- a/Prism.CommonDialogPack/ViewModels/ColorPickerDialogViewModel.cs
+++ b/Prism.CommonDialogPack/ViewModels/ColorPickerDialogViewModel.cs
@@ -67,6 +67,13 @@ namespace Prism.CommonDialogPack.ViewModels
             private set { SetProperty(ref customColors, value); }
         }
 
+        private HSV defaultHSV;
+        public HSV DefaultHSV
+        {
+            get { return defaultHSV; }
+            set { SetProperty(ref defaultHSV, value); }
+        }
+
         private RGB selectedBasicColor;
         /// <summary>
         /// Selected RGB in BasicColors.
@@ -444,6 +451,78 @@ namespace Prism.CommonDialogPack.ViewModels
             if (parameters.TryGetValue(DialogParameterNames.AddCustomColorButtonText, out string addCustomColorButtonText))
             {
                 this.AddCustomColorButtonText = addCustomColorButtonText;
+            }
+            if (parameters.TryGetValue(DialogParameterNames.DefaultColor, out RGB defaultRGB))
+            {
+                HSV hsv = defaultRGB.ToHSV();
+                this.DefaultHSV = hsv;
+                if (BasicColors.RGB.Any(x => x == defaultRGB))
+                {
+                    RGB target = BasicColors.RGB.First(x => x == defaultRGB);
+                    this.SelectedBasicColor = target;
+                }
+                if (this.CustomColors.Any(x => x.RGB == defaultRGB))
+                {
+                    RGBWithIndexViewModel target = this.CustomColors.First(x => x.RGB == defaultRGB);
+                    this.SelectedCutomColor = target;
+                }
+                this.DisplayRed = defaultRGB.R.ToString();
+                this.DisplayGreen = defaultRGB.G.ToString();
+                this.DisplayBlue = defaultRGB.B.ToString();
+                this.DisplayHue = Math.Round(hsv.H).ToString();
+                this.DisplaySaturation = Math.Round(hsv.S * 100).ToString();
+                this.DisplayBrightness = Math.Round(hsv.V * 100).ToString();
+                this.DisplayColorCode = defaultRGB.ToColorCode();
+                this.CurrentRGB = defaultRGB;
+                this.currentHSV = hsv;
+            }
+            else if (parameters.TryGetValue(DialogParameterNames.DefaultColor, out HSV defaultHSV))
+            {
+                RGB rgb = defaultHSV.ToRGB();
+                this.DefaultHSV = defaultHSV;
+                if (BasicColors.RGB.Any(x => x == rgb))
+                {
+                    RGB target = BasicColors.RGB.First(x => x == rgb);
+                    this.SelectedBasicColor = target;
+                }
+                if (this.CustomColors.Any(x => x.RGB == rgb))
+                {
+                    RGBWithIndexViewModel target = this.CustomColors.First(x => x.RGB == rgb);
+                    this.SelectedCutomColor = target;
+                }
+                this.DisplayRed = rgb.R.ToString();
+                this.DisplayGreen = rgb.G.ToString();
+                this.DisplayBlue = rgb.B.ToString();
+                this.DisplayHue = Math.Round(defaultHSV.H).ToString();
+                this.DisplaySaturation = Math.Round(defaultHSV.S * 100).ToString();
+                this.DisplayBrightness = Math.Round(defaultHSV.V * 100).ToString();
+                this.DisplayColorCode = rgb.ToColorCode();
+                this.CurrentRGB = rgb;
+                this.currentHSV = defaultHSV;
+            }
+            else if (parameters.TryGetValue(DialogParameterNames.DefaultColor, out string colorCode) && Converters.ColorConverter.TryStringToRGB(colorCode, out RGB rgb))
+            {
+                HSV hsv = rgb.ToHSV();
+                this.DefaultHSV = hsv;
+                if (BasicColors.RGB.Any(x => x == rgb))
+                {
+                    RGB target = BasicColors.RGB.First(x => x == rgb);
+                    this.SelectedBasicColor = target;
+                }
+                if (this.CustomColors.Any(x => x.RGB == rgb))
+                {
+                    RGBWithIndexViewModel target = this.CustomColors.First(x => x.RGB == rgb);
+                    this.SelectedCutomColor = target;
+                }
+                this.DisplayRed = rgb.R.ToString();
+                this.DisplayGreen = rgb.G.ToString();
+                this.DisplayBlue = rgb.B.ToString();
+                this.DisplayHue = Math.Round(hsv.H).ToString();
+                this.DisplaySaturation = Math.Round(hsv.S * 100).ToString();
+                this.DisplayBrightness = Math.Round(hsv.V * 100).ToString();
+                this.DisplayColorCode = colorCode;
+                this.CurrentRGB = rgb;
+                this.currentHSV = hsv;
             }
         }
         /// <summary>

--- a/Prism.CommonDialogPack/ViewModels/ColorPickerDialogViewModel.cs
+++ b/Prism.CommonDialogPack/ViewModels/ColorPickerDialogViewModel.cs
@@ -27,6 +27,36 @@ namespace Prism.CommonDialogPack.ViewModels
         /// </summary>
         public DelegateCommand AddCustomColorCommand => this.addCustomColorCommand ??= new DelegateCommand(this.AddCustomColor, this.CanAddCustomColor);
 
+        public string okButtonText = "OK";
+        /// <summary>
+        /// OK button text.
+        /// </summary>
+        public string OKButtonText
+        {
+            get { return this.okButtonText; }
+            set { SetProperty(ref this.okButtonText, value); }
+        }
+
+        public string cancelButtonText = "キャンセル";
+        /// <summary>
+        /// Cancel button text.
+        /// </summary>
+        public string CancelButtonText
+        {
+            get { return this.cancelButtonText; }
+            set { SetProperty(ref this.cancelButtonText, value); }
+        }
+
+        public string addCustomColorButtonText = "カスタムカラーへ追加";
+        /// <summary>
+        /// AddCustomColor button text.
+        /// </summary>
+        public string AddCustomColorButtonText
+        {
+            get { return this.addCustomColorButtonText; }
+            set { SetProperty(ref this.addCustomColorButtonText, value); }
+        }
+
         private RGBWithIndexViewModel[] customColors;
         /// <summary>
         /// CustomColors.
@@ -402,6 +432,18 @@ namespace Prism.CommonDialogPack.ViewModels
             else
             {
                 this.CustomColors = Enumerable.Range(0, 16).Select(i => new RGBWithIndexViewModel(new RGB(255, 255, 255), i)).ToArray();
+            }
+            if (parameters.TryGetValue(DialogParameterNames.OKButtonText, out string okButtonText))
+            {
+                this.OKButtonText = okButtonText;
+            }
+            if (parameters.TryGetValue(DialogParameterNames.CancelButtonText, out string cancelButtonText))
+            {
+                this.CancelButtonText = cancelButtonText;
+            }
+            if (parameters.TryGetValue(DialogParameterNames.AddCustomColorButtonText, out string addCustomColorButtonText))
+            {
+                this.AddCustomColorButtonText = addCustomColorButtonText;
             }
         }
         /// <summary>

--- a/Prism.CommonDialogPack/ViewModels/DialogViewModelBase.cs
+++ b/Prism.CommonDialogPack/ViewModels/DialogViewModelBase.cs
@@ -97,6 +97,14 @@ namespace Prism.CommonDialogPack.ViewModels
             {
                 this.WindowStyle = windwoStyle;
             }
+            else if (parameters.TryGetValue(DialogParameterNames.WindowStyle, out string resourceKey))
+            {
+                object result = Application.Current.TryFindResource(resourceKey);
+                if (result != null && result is Style windowStyle)
+                {
+                    this.WindowStyle = windowStyle;
+                }
+            }
             if (parameters.TryGetValue(DialogParameterNames.Width, out double width))
             {
                 this.Width = width;

--- a/Prism.CommonDialogPack/Views/ColorPickerDialog.xaml
+++ b/Prism.CommonDialogPack/Views/ColorPickerDialog.xaml
@@ -151,7 +151,8 @@
         </UniformGrid>
         <Grid Grid.Column="1" Margin="10">
             <controls:HSVPicker HSV="{Binding InputHSV}"
-                                SelectedHSV="{Binding SelectedHSV, Mode=OneWayToSource}">
+                                SelectedHSV="{Binding SelectedHSV, Mode=OneWayToSource}"
+                                DefaultHSV="{Binding DefaultHSV}">
                 <controls:HSVPicker.Resources>
                     <Style TargetType="{x:Type controls:HSPicker}">
                         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"/>

--- a/Prism.CommonDialogPack/Views/ColorPickerDialog.xaml
+++ b/Prism.CommonDialogPack/Views/ColorPickerDialog.xaml
@@ -141,11 +141,11 @@
         <UniformGrid Grid.Row="2"
                      Rows="1"
                      Margin="10">
-            <Button Content="OK"
+            <Button Content="{Binding OKButtonText}"
                     Command="{Binding OKCommand}"
                     Margin="0, 0, 10, 0"
                     Height="30"/>
-            <Button Content="Cancel"
+            <Button Content="{Binding CancelButtonText}"
                     Command="{Binding CancelCommand}"
                     Margin="10, 0, 0, 0"/>
         </UniformGrid>
@@ -329,7 +329,7 @@
                 Grid.Column="1"
                 Height="30"
                 Margin="5"
-                Content="Add to Custom Colors"
+                Content="{Binding AddCustomColorButtonText}"
                 Command="{Binding AddCustomColorCommand}"/>
     </Grid>
 </UserControl>

--- a/Prism.CommonDialogPack/Views/ConfirmationDialog.xaml
+++ b/Prism.CommonDialogPack/Views/ConfirmationDialog.xaml
@@ -13,6 +13,7 @@
         </Grid.RowDefinitions>
         <TextBlock HorizontalAlignment="Stretch"
                    VerticalAlignment="Stretch"
+                   TextWrapping="Wrap"
                    Text="{Binding Message}"/>
         <StackPanel Grid.Row="1"
                     Orientation="Horizontal"

--- a/Prism.CommonDialogPack/Views/NotificationDialog.xaml
+++ b/Prism.CommonDialogPack/Views/NotificationDialog.xaml
@@ -12,6 +12,7 @@
         </Grid.RowDefinitions>
         <TextBlock HorizontalAlignment="Stretch"
                    VerticalAlignment="Stretch"
+                   TextWrapping="Wrap"
                    Text="{Binding Message}"/>
         <Button x:Name="OKButton"
                 Command="{Binding CloseDialogCommand}"

--- a/Prism.CommonDialogPack/Views/ProgressDialog.xaml
+++ b/Prism.CommonDialogPack/Views/ProgressDialog.xaml
@@ -14,6 +14,7 @@
         </Grid.RowDefinitions>
         <TextBlock HorizontalAlignment="Stretch"
                    VerticalAlignment="Stretch"
+                   TextWrapping="Wrap"
                    Text="{Binding Message}"/>
         <StackPanel Grid.Row="1"
                     Margin="10, 0">


### PR DESCRIPTION
# 修正
メッセージを表示するダイアログで表示するメッセージが範囲外になる場合に折り返して表示されるように修正。
対象のダイアログは下記の通り。

* NotificationDialog
* ConfirmationDialog
* ProgressDialog

# 機能追加
## 全般
WindowStyle を StyleKey の文字列で指定できる機能を追加
例）
```csharp
var param = new DialogParameters
{
    { DialogParameterNames.WindowStyle, "dialogStyle" },
};
```

## ColorPickerDialog
DialogParameter で指定可能なパラメーターを追加

* OKButton のテキスト
* CancelButton のテキスト
* AddCustomColorButton のテキスト
* 初期選択色

例）
```csharp
var param = new DialogParameters()
{
    // RGB, HSV, ColorCode が指定可能
    { DialogParameterNames.DefaultColor, new RGB(255, 255, 0) },
    //{ DialogParameterNames.DefaultColor, new HSV(60, 1, 1) },
    //{ DialogParameterNames.DefaultColor, "#FFFF00" },
};
```